### PR TITLE
Whitespace cleanup for Github ids

### DIFF
--- a/lib/ldapclient.php
+++ b/lib/ldapclient.php
@@ -55,7 +55,8 @@ class LDAPClient {
               # $et contains GITHIB:id  or BITBUCKET:id
               $id = explode(":", $et);
               if($id[0] == "GITHUB") {
-                return $id[1];
+		#Clean whitespace from the id.
+                return trim($id[1]);
                 last;
               }
             }


### PR DESCRIPTION
Just in case whitespace stripping elsewhere fails, clean it up here.