### PR TITLE
Proposed change for multiple accounts with the same GitHub id

### DIFF
--- a/lib/ldapclient.php
+++ b/lib/ldapclient.php
@@ -78,8 +78,13 @@ class LDAPClient {
       $sr = ldap_search($ds, $this->dn, "(employeeType=GITHUB:$gh)", array("mail"));
       $info = ldap_get_entries($ds, $sr);
       if($info["count"] > 0) {
-        if(isset($info[0]["mail"])) {
-          return $info[0]["mail"][0];
+	#loop through 'all' results and only return the email associated with committers
+        for ( $i = 0; $i <= $info["count"]; $i++ ){
+          if ( strpos($info[0]["dn"],"ou=people") !== FALSE ){
+            if(isset($info[$i]["mail"])) {
+              return $info[$i]["mail"][0];
+            }
+          }
         }
       }
     }

--- a/lib/ldapclient.php
+++ b/lib/ldapclient.php
@@ -80,7 +80,7 @@ class LDAPClient {
       if($info["count"] > 0) {
 	#loop through 'all' results and only return the email associated with committers
         for ( $i = 0; $i <= $info["count"]; $i++ ){
-          if ( strpos($info[0]["dn"],"ou=people") !== FALSE ){
+          if ( strpos($info[$i]["dn"],"ou=people") !== FALSE ){
             if(isset($info[$i]["mail"])) {
               return $info[$i]["mail"][0];
             }


### PR DESCRIPTION
The goal here is to prevent users from being 'spammed' with multiple removals and invites if they happen to have 2 ldap accounts with the same GitHub id.  It's rare but it does happen

Signed-off-by: Eclipse Webmaster <webmaster@eclipse.org>